### PR TITLE
Add Default RPC URL Fallback in parse_rpc_url Function

### DIFF
--- a/crates/etop-cli/src/commands/tui_command.rs
+++ b/crates/etop-cli/src/commands/tui_command.rs
@@ -2,6 +2,7 @@ use crate::Cli;
 use etop_core::{EtopError, EtopState, Window, WindowSize};
 
 const DEFAULT_DATASET: &str = "transactions_by_to_address";
+const DEFAULT_RPC_URL: &str = "https://ethereum.publicnode.com";
 
 pub(crate) async fn tui_command(args: Cli) -> Result<(), EtopError> {
     let etop_state =
@@ -81,13 +82,9 @@ async fn create_rpc_source(
 }
 
 fn parse_rpc_url(rpc_url: Option<String>) -> Option<String> {
-    let mut url = match rpc_url {
-        Some(url) => url.clone(),
-        _ => match std::env::var("ETH_RPC_URL") {
-            Ok(url) => url,
-            Err(_e) => return None,
-        },
-    };
+    let mut url = rpc_url
+        .or_else(|| std::env::var("ETH_RPC_URL").ok())
+        .unwrap_or_else(|| DEFAULT_RPC_URL.to_string());
     if !url.starts_with("http") {
         url = "http://".to_string() + url.as_str();
     };

--- a/crates/etop-cli/src/commands/tui_command.rs
+++ b/crates/etop-cli/src/commands/tui_command.rs
@@ -2,7 +2,7 @@ use crate::Cli;
 use etop_core::{EtopError, EtopState, Window, WindowSize};
 
 const DEFAULT_DATASET: &str = "transactions_by_to_address";
-const DEFAULT_RPC_URL: &str = "https://ethereum.publicnode.com";
+const DEFAULT_RPC_URL: &str = "https://eth.llamarpc.com";
 
 pub(crate) async fn tui_command(args: Cli) -> Result<(), EtopError> {
     let etop_state =


### PR DESCRIPTION
## Summary
This PR introduces a modification to the `parse_rpc_url` function to use a default RPC URL when neither the `--rpc` command line argument nor the `ETH_RPC_URL` environment variable is provided. This enhancement ensures greater flexibility and ease of use, especially in development or testing environments where specifying an RPC URL might not always be convenient.

## Changes
- Updated the `parse_rpc_url` function in [filename].rs to check for the presence of `--rpc` argument or `ETH_RPC_URL` environment variable.
- If neither is available, the function now defaults to a predefined RPC URL (`https://ethereum.publicnode.com`).
- Ensured that the URL is correctly formatted with the "http" prefix.

## Motivation
In the current implementation, users are required to provide an RPC URL either through the command line or environment variables. However, in some scenarios like local development or testing, it might be more efficient to have a sensible default. This change aims to simplify the process and improve the user experience by reducing the need for explicit configuration in such cases.

## Test Plan
- Tested the function with the `--rpc` argument, an environment variable, and without both to ensure the default URL is used correctly.
- Ensured existing tests pass and no new issues are introduced.

## Potential Impacts
- This change should not impact existing users who specify an RPC URL.
- Users who do not specify an RPC URL will now connect to the default URL, which should be clearly documented.

Please review this PR and provide feedback or approval. Thank you!