### PR TITLE
feat(etop-cli) Integrate polling interval 

### DIFF
--- a/crates/etop-cli/src/args.rs
+++ b/crates/etop-cli/src/args.rs
@@ -27,4 +27,8 @@ pub struct Cli {
     /// print formatted data without interactive interface
     #[clap(short, long)]
     pub print: bool,
+
+    /// Set the polling rate in seconds
+    #[clap(long, default_value_t = 1.0)]
+    pub poll: f64,
 }

--- a/crates/etop-cli/src/commands/tui_command.rs
+++ b/crates/etop-cli/src/commands/tui_command.rs
@@ -8,7 +8,7 @@ pub(crate) async fn tui_command(args: Cli) -> Result<(), EtopError> {
         create_etop_state(args.dataset, args.block, args.window, args.rpc, args.data_dir).await?;
 
     // run main function
-    etop_tui::tokio_main(Some(etop_state))
+    etop_tui::tokio_main(Some(etop_state), args.poll)
         .await
         .map_err(|e| EtopError::TuiError(format!("{:?}", e)))
         .ok();

--- a/crates/etop-tui/src/app.rs
+++ b/crates/etop-tui/src/app.rs
@@ -27,10 +27,16 @@ pub struct App {
     pub mode: Mode,
     pub last_tick_key_events: Vec<KeyEvent>,
     pub data: EtopState,
+    pub poll_rate: f64,
 }
 
 impl App {
-    pub fn new(tick_rate: f64, frame_rate: f64, data: Option<EtopState>) -> Result<Self> {
+    pub fn new(
+        tick_rate: f64,
+        frame_rate: f64,
+        data: Option<EtopState>,
+        poll_rate: f64,
+    ) -> Result<Self> {
         let header = Header::new();
         let body = Body::new();
 
@@ -58,6 +64,7 @@ impl App {
             mode: Mode::Home,
             last_tick_key_events: Vec::new(),
             data,
+            poll_rate,
         })
     }
 
@@ -120,6 +127,7 @@ impl App {
                     //
                     // // etop setup
                     Action::BeginBlockSubscription => {
+                        let dataa = self.poll_rate.clone();
                         let action_tx = action_tx.clone();
                         let data = self.data.clone();
                         tokio::spawn(async move {
@@ -137,7 +145,7 @@ impl App {
                                         let _ = action_tx.send(Action::CheckBlockSet);
                                     }
                                 };
-                                tokio::time::sleep(Duration::from_secs(1)).await;
+                                tokio::time::sleep(Duration::from_secs_f64(dataa)).await;
                             }
                         });
                     }
@@ -295,7 +303,7 @@ impl App {
                 tui.enter()?;
             } else if self.should_quit {
                 tui.stop()?;
-                break;
+                break
             }
         }
         tui.exit()?;

--- a/crates/etop-tui/src/lib.rs
+++ b/crates/etop-tui/src/lib.rs
@@ -18,12 +18,13 @@ use crate::{
 use color_eyre::eyre::Result;
 use etop_core::EtopState;
 
-pub async fn tokio_main(data: Option<EtopState>) -> Result<()> {
+pub async fn tokio_main(data: Option<EtopState>, poll_rate: f64) -> Result<()> {
     initialize_logging()?;
     initialize_panic_handler()?;
+
     let tick_rate = 1.0;
     let frame_rate = 10.0;
-    let mut app = App::new(tick_rate, frame_rate, data)?;
+    let mut app = App::new(tick_rate, frame_rate, data, poll_rate)?;
     app.run().await?;
     Ok(())
 }


### PR DESCRIPTION
Intro to a a new --poll argument in the CLI, allowing users to custom the polling interval. Prev fixed at one second, this update provides the flexibility to set varied polling rates, such as 0.5 seconds or 10 seconds :)